### PR TITLE
Set Docker default command to Nest insight generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,6 @@ RUN npm install
 
 # Copy the rest of the application code
 COPY . .
+
+# Set the default command to run the Nest insight generator
+CMD ["node", "generateNestInsight.js"]


### PR DESCRIPTION
## Summary
- set the default Docker command to execute the Nest insight generator script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9000719b0832aa5654b413ef133a9