### PR TITLE
Fix Home Assistant history date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To generate insights for home management, run the following commands:
    ```
 
 ## Configuration
-You can customize the behavior of the application by modifying the `config.js` file. This includes setting up entity IDs, adjusting time ranges, and configuring judge personalities for insight evaluation.
+You can customize the behavior of the application by modifying the `config.js` file. This includes setting up entity IDs, adjusting time ranges, and configuring judge personalities for insight evaluation. When adjusting time ranges, remember that the `days` argument passed to `fetchEntityHistory` is inclusive—for example, requesting `3` days returns data for today and the previous two days.
 
 ## Contributing
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/homeAssistant.js
+++ b/homeAssistant.js
@@ -10,7 +10,7 @@ const {
  * Fetches the history of a specific entity from Home Assistant for a given number of days.
  *
  * @param {string} entityId - The ID of the entity to fetch history for.
- * @param {number} [days=1] - The number of days of history to fetch.
+ * @param {number} [days=1] - The number of days of history to fetch, inclusive of the current day.
  * @returns {Promise<Array>} - A promise that resolves to the entity history data.
  */
 async function fetchEntityHistory(entityId, days = 1) {
@@ -20,8 +20,8 @@ async function fetchEntityHistory(entityId, days = 1) {
   // Set endTime to the end of today (23:59:59.999) in the specified timezone
   const endDate = now.endOf('day')
 
-  // Set startTime to the start of the day 'days' days ago (00:00:00.000) in the specified timezone
-  const startDate = endDate.minus({ days: days }).startOf('day')
+  // Set startTime to the start of the day so the range covers the requested number of days inclusively
+  const startDate = endDate.minus({ days: Math.max(days - 1, 0) }).startOf('day')
 
   // Format the dates in ISO format with the correct timezone offset
   const startTime = startDate.toISO()


### PR DESCRIPTION
## Summary
- ensure fetchEntityHistory includes the current day when calculating the start of the requested range
- document the inclusive days behaviour for fetchEntityHistory in the README

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8ffedf480832a8e1483a9fc8d4a17