### PR TITLE
Handle non-numeric insight scores

### DIFF
--- a/generateTimeInsight.js
+++ b/generateTimeInsight.js
@@ -24,8 +24,23 @@ async function main() {
     const evaluations = await Promise.all(
       insightVersions.map(async (insight) => {
         const scores = await evaluateInsight(insight)
-        const averageScore =
-          scores.reduce((sum, score) => sum + score.score, 0) / scores.length
+
+        const { sum, count } = scores.reduce(
+          (accumulator, score) => {
+            const numericScore = Number(score.score)
+
+            if (Number.isFinite(numericScore)) {
+              accumulator.sum += numericScore
+              accumulator.count += 1
+            }
+
+            return accumulator
+          },
+          { sum: 0, count: 0 }
+        )
+
+        const averageScore = count > 0 ? sum / count : 0
+
         return {
           insight,
           averageScore,


### PR DESCRIPTION
## Summary
- convert evaluation scores to numbers before averaging
- skip invalid score values and default the average to 0 when none remain

## Testing
- node generateTimeInsight.js *(fails: Missing OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ffe4ba38832ab90eae53fa92bc90